### PR TITLE
Added Ajax to word list

### DIFF
--- a/styleguide/index.md
+++ b/styleguide/index.md
@@ -834,6 +834,7 @@ _Alphabetical Word List: Default Spellings_
 * ad hoc
 * ADO.NET
 * Agile (cap when referring to Agile software development or when used on its own as a noun)
+* Ajax
 * a.k.a. or aka (be consistent)
 * a.m. or A.M.
 * Alt key


### PR DESCRIPTION
Ajax and not AJAX seems to be the right way to write it.

This is based on the fact that it is now a term on its own, and no longer an acronym (which had too narrow a meaning) - https://snook.ca/archives/javascript/ajax_vs_ajax
Also discussed with @kristenORM in #15