### PR TITLE
Add new SQL command conventions to font table

### DIFF
--- a/styleguide/index.md
+++ b/styleguide/index.md
@@ -793,7 +793,7 @@ title: O'Reilly Style Guide
 </thead>
 <tbody>
 <tr>
-<td><p>Filenames, file extensions (such as .jpeg), directory paths, libraries, and commands in Unix, Oracle, SQL, and Linux books</p></td>
+<td><p>Filenames, file extensions (such as .jpeg), directory paths, libraries, and commands in Unix, Oracle, and Linux books</p></td>
 <td><p><em>Body font italic</em></p></td>
 </tr>
 <tr>
@@ -817,8 +817,13 @@ title: O'Reilly Style Guide
 <td><p><code>Constant width</code></p></td>
 </tr>
 <tr>
-<td><p>Language and script elements: class names, types, namespaces, attributes, methods, variables, keywords, functions, modules, commands, properties, parameters, values, objects, events, XML and HTML tags, and similar elements. Some examples include: <code>System.Web.UI</code>, a <code>while</code> loop, the <code>Socket</code> class, and the <code>Obsolete</code> attribute. <strong>Exception:</strong> commands in Unix, Oracle, SQL, and Linux book, which are regular italics.</p></td>
+<td><p>Language and script elements: class names, types, namespaces, attributes, methods, variables, keywords, functions, modules, commands, properties, parameters, values, objects, events, XML and HTML tags, and similar elements. Some examples include: <code>System.Web.UI</code>, a <code>while</code> loop, the <code>Socket</code> class, and the <code>Obsolete</code> attribute. <strong>Exception:</strong> commands in Unix, Oracle, and Linux book, which are regular italics.</p></td>
 <td><p><code>Constant width</code></p></td>
+</tr>
+<tr>
+<tr>
+ <td><p>SQL commands (<code>SELECT</code>, <code>INSERT</code>, <code>ALTER TABLE</code>, <code>CREATE INDEX</code>, etc.)</p></td>
+<td><p><code>CONSTANT WIDTH CAPS</code></p></td>
 </tr>
 <tr>
 <td><p>Replaceable items (placeholder items in syntax); “username” in the following example is a placeholder:


### PR DESCRIPTION
I've added a new row to the Typography and Font Conventions table for SQL commands (all caps CW) and removed a couple mentions of using italic for these. I didn't bold these changes to mark them as new, because I didn't want to add confusion.