### PR TITLE
Removing ital for Linux, Unix, Oracle commands

### DIFF
--- a/styleguide/index.md
+++ b/styleguide/index.md
@@ -792,7 +792,7 @@ title: O'Reilly Style Guide
 </thead>
 <tbody>
 <tr>
-<td><p>Filenames, file extensions (such as .jpeg), directory paths, libraries, and commands in Unix, Oracle, and Linux books</p></td>
+<td><p>Filenames, file extensions (such as .jpeg), directory paths, and libraries.</p></td>
 <td><p><em>Body font italic</em></p></td>
 </tr>
 <tr>
@@ -816,12 +816,12 @@ title: O'Reilly Style Guide
 <td><p><code>Constant width</code></p></td>
 </tr>
 <tr>
-<td><p>Language and script elements: class names, types, namespaces, attributes, methods, variables, keywords, functions, modules, commands, properties, parameters, values, objects, events, XML and HTML tags, and similar elements. Some examples include: <code>System.Web.UI</code>, a <code>while</code> loop, the <code>Socket</code> class, and the <code>Obsolete</code> attribute. <strong>Exception:</strong> commands in Unix, Oracle, and Linux books, which are regular italics.</p></td>
+<td><p>Language and script elements: class names, types, namespaces, attributes, methods, variables, keywords, functions, modules, commands, properties, parameters, values, objects, events, XML and HTML tags, and similar elements. Some examples include: <code>System.Web.UI</code>, a <code>while</code> loop, the <code>Socket</code> class, the <code>grep</code> command, and the <code>Obsolete</code> attribute.</p></td>
 <td><p><code>Constant width</code></p></td>
 </tr>
 <tr>
- <td><p>SQL commands (<code>SELECT</code>, <code>INSERT</code>, <code>ALTER TABLE</code>, <code>CREATE INDEX</code>, etc.)</p></td>
-<td><p><code>CONSTANT WIDTH CAPS</code></p></td>
+ <td><p>SQL commands (<code>SELECT</code>, <code>INSERT</code>, <code>ALTER</code> <code>TABLE</code>, <code>CREATE</code> <code>INDEX</code>, etc.)</p></td>
+ <td><p><code>CONSTANT</code> <code>WIDTH</code> <code>CAPS</code></p></td>
 </tr>
 <tr>
 <td><p>Replaceable items (placeholder items in syntax); “username” in the following example is a placeholder:


### PR DESCRIPTION
PE group agreed to officially set Linux, Unix, and Oracle commands in code font going forward. I removed this exception from the font conventions table.