### PR TITLE
Consistent treatment of abbreviated units of measure

### DIFF
--- a/styleguide/index.md
+++ b/styleguide/index.md
@@ -115,7 +115,7 @@ title: O'Reilly Style Guide
 <p>A.M. and P.M. or a.m. and p.m.—be consistent.</p>
 </li>
 <li>
-<p>K = 1,024; k = 1,000. So a 56 kbps modem is equal to 56,000 bps, while 64K of memory is equal to 65,536.</p>
+<p>K = 1,024; k = 1,000. So a 56 kbps modem is equal to 56,000 bps, while 64 K of memory is equal to 65,536.</p>
 </li>
 <li>
 <p>In units of measure, do not use a hyphen. For example, it’s 32 MB hard drive, not 32-MB hard drive. (Though when the unit is spelled out, use a hyphen, e.g., 32-megabyte hard drive.)</p>


### PR DESCRIPTION
Propose adding a word space between "64" and "K" in "64 K of memory," for consistency with open-style treatment of "56 kbps," "32 MB," etc. Current language makes it seem as though we recommend different styles for units of measure with single-character abbreviations and units of measure with multi-character abbreviations. Including a space in both cases, with few, specific exceptions (e.g., 36°C), would align with CMoS 10.49: https://www.chicagomanualofstyle.org/book/ed17/part2/ch10/psec049.html.