### PR TITLE
Default to https for static link

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -3,7 +3,7 @@
 		<head>
 			<title>{{ page.title }}</title>
 			<!-- link to main stylesheet -->
-		<link rel="stylesheet" type="text/css" href="http://oreillymedia.github.io/production-resources/css/main.css">
+		<link rel="stylesheet" type="text/css" href="https://oreillymedia.github.io/production-resources/css/main.css">
 		</head>
 		<body>
 			<nav>


### PR DESCRIPTION
If you visit https://oreillymedia.github.io/production-resources/styleguide/ (https), the page won't load the CSS because it's coming from an unsecure source; this should allow both http and https to work fine (since http doesn't care, as long as it can find the file).